### PR TITLE
Bumped version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-sassy-mixins",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "PostCSS plugin for sass-like mixins",
   "keywords": [
     "postcss",


### PR DESCRIPTION
You'll need to do `npm publish` to update the package @ npmjs, we aren't getting the last version without the error messages because of this ( I think ).
