### PR TITLE
postcss 6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = postcss.plugin('postcss-sassy-mixins', function (opts) {
 				if (decl.args) decl.args.forEach(function (arg, i) {
 					values[arg[0]] = params[i] || arg[1];
 				});
-        var clones = mixin.nodes.map(function (node) {
+				var clones = mixin.nodes.map(function (node) {
 					return node.clone();
 				});
 				var proxy = postcss.rule({ nodes: clones });

--- a/index.js
+++ b/index.js
@@ -127,25 +127,26 @@ module.exports = postcss.plugin('postcss-sassy-mixins', function (opts) {
 				if (decl.args) decl.args.forEach(function (arg, i) {
 					values[arg[0]] = params[i] || arg[1];
 				});
-				var clones = [];
-				mixin.nodes.forEach(function(node) {
-					clones.push(node.clone());
+        var clones = mixin.nodes.map(function (node) {
+					return node.clone();
 				});
 				var proxy = postcss.rule({ nodes: clones });
 				if (decl.args) vars({ only: values })(proxy);
 				if (decl.content) {
 					proxy.walkAtRules('content', function (place) {
 						if (typeof rule.nodes !== 'undefined')
-							place.replaceWith(rule.nodes);
+							place.replaceWith(rule.nodes.map(function (node) {
+								return node.clone();
+							}));
 						else place.remove();
 					});
 				}
-				rule.parent.insertBefore(rule, proxy.nodes);
+				rule.before(proxy.nodes);
 				proxy.walkAtRules('include', includeMixin);
 			}
 			else {
 				var root = objectToNodes(postcss.root(), mixin, rule.source);
-				rule.parent.insertBefore(rule, root);
+				rule.before(root);
 			}
 		}
 		rule.remove();

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/andyjansson/postcss-sassy-mixins#readme",
   "dependencies": {
     "glob": "^6.0.4",
-    "postcss": "^5.0.14",
-    "postcss-simple-vars": "^1.2.0"
+    "postcss": "^6.0.2",
+    "postcss-simple-vars": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -83,17 +83,17 @@ describe('postcss-sassy-mixins', function () {
 
 	it('supports mixins with content', function () {
 		test('@mixin m { @media { @content; } } @include m { a {} }',
-			'@media {\n    a {}\n}');
+			' @media { a {} }');
 	});
 
 	it('supports mixins with optional content', function () {
 		test('@mixin m { @media { @content; } } @include m;',
-			'@media {}');
+			' @media { }');
 	});
 
 	it('supports using supplied arguments', function () {
 		test('@mixin m($a, $b: b, $c: c) { v: $a $b $c; } @include m(1, 2);',
-			'v: 1 2 c;');
+			' v: 1 2 c;');
 	});
 
 	it('supports loading mixins from a directory', function () {


### PR DESCRIPTION
Hi !
Postcss api has changed since version 6:
https://github.com/postcss/postcss/releases/tag/6.0.0
And now:
`if node already had a parent, insert methods (append, insertAfter, etc) will not clone it anymore`

So if you have two `@content`s in mixin, sassy-mixins replace first and remove second match.